### PR TITLE
Implement YNAB budget helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,33 @@
-# budgetapp
+# Budget Helper
+
+This project provides a simple command line helper for [YNAB](https://www.youneedabudget.com/) budgets. It can fetch your budget categories, suggest moves to cover overspending and, if requested, apply those changes using the YNAB API.
+
+## Requirements
+
+- Python 3.8+
+- `requests` (see `requirements.txt`)
+
+Install dependencies with:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Usage
+
+Set the environment variable `YNAB_TOKEN` to your personal access token. Then run:
+
+```bash
+python budget_cli.py <budget_id>
+```
+
+Add `--apply` to automatically make the suggested adjustments. You can also specify a month with `--month YYYY-MM-01`.
+
+## Development
+
+Tests can be run with:
+
+```bash
+pytest
+```
+

--- a/budget_cli.py
+++ b/budget_cli.py
@@ -1,0 +1,56 @@
+import argparse
+import os
+
+from ynab_helper import YNABClient, recommend_changes
+
+
+def main():
+    parser = argparse.ArgumentParser(description="YNAB budget helper")
+    parser.add_argument("budget_id", help="YNAB budget ID")
+    parser.add_argument(
+        "--month", default=None, help="Budget month (YYYY-MM-01). Defaults to current month"
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Apply recommended changes to YNAB",
+    )
+    args = parser.parse_args()
+
+    token = os.environ.get("YNAB_TOKEN")
+    if not token:
+        parser.error("Environment variable YNAB_TOKEN must be set")
+
+    client = YNABClient(token)
+    categories = client.get_month_categories(args.budget_id, args.month)
+    moves = recommend_changes(categories)
+
+    if not moves:
+        print("No recommendations. Budget looks good!")
+        return
+
+    print("Recommended moves:")
+    for m in moves:
+        print(f"  Move {m['amount']/1000:.2f} from {m['from']} to {m['to']}")
+
+    if args.apply:
+        month = args.month
+        if month is None:
+            import datetime
+
+            month = datetime.date.today().strftime("%Y-%m-01")
+        current = {c.id: c for c in client.get_month_categories(args.budget_id, month)}
+        for m in moves:
+            from_cat = current[m["from"]]
+            to_cat = current[m["to"]]
+            client.update_category_budget(
+                args.budget_id, month, from_cat.id, from_cat.budgeted - m["amount"]
+            )
+            client.update_category_budget(
+                args.budget_id, month, to_cat.id, to_cat.budgeted + m["amount"]
+            )
+        print("Changes applied.")
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+requests

--- a/tests/test_recommendation.py
+++ b/tests/test_recommendation.py
@@ -1,0 +1,25 @@
+import sys
+import types
+sys.modules["requests"] = types.ModuleType("requests")
+sys.modules["requests"].Session = lambda: None
+import os
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+import ynab_helper as yh
+
+
+def test_recommend_changes_basic():
+    cats = [
+        yh.Category(id="a", name="A", budgeted=1000, balance=2000),
+        yh.Category(id="b", name="B", budgeted=1000, balance=-500),
+        yh.Category(id="c", name="C", budgeted=1000, balance=1000),
+        yh.Category(id="d", name="D", budgeted=1000, balance=-300),
+    ]
+    moves = yh.recommend_changes(cats)
+    total_move = sum(m["amount"] for m in moves)
+    assert total_move == 800
+    # after applying moves to categories, no overspent remains
+    balances = {c.id: c.balance for c in cats}
+    for m in moves:
+        balances[m["from"]] -= m["amount"]
+        balances[m["to"]] += m["amount"]
+    assert all(b >= 0 for b in balances.values())

--- a/ynab_helper.py
+++ b/ynab_helper.py
@@ -1,0 +1,77 @@
+import datetime
+from dataclasses import dataclass
+from typing import List, Dict
+
+import requests
+
+
+@dataclass
+class Category:
+    id: str
+    name: str
+    budgeted: int
+    balance: int
+
+
+class YNABClient:
+    """Simple client for the YNAB API."""
+
+    BASE_URL = "https://api.youneedabudget.com/v1"
+
+    def __init__(self, access_token: str):
+        self.session = requests.Session()
+        self.session.headers.update({"Authorization": f"Bearer {access_token}"})
+
+    def get_budgets(self) -> Dict:
+        resp = self.session.get(f"{self.BASE_URL}/budgets")
+        resp.raise_for_status()
+        return resp.json()
+
+    def get_month_categories(self, budget_id: str, month: str = None) -> List[Category]:
+        if month is None:
+            month = datetime.date.today().strftime("%Y-%m-01")
+        url = f"{self.BASE_URL}/budgets/{budget_id}/months/{month}"
+        resp = self.session.get(url)
+        resp.raise_for_status()
+        data = resp.json()
+        categories = []
+        for grp in data["data"]["month"]["categories"]:
+            categories.append(
+                Category(
+                    id=grp["id"],
+                    name=grp["name"],
+                    budgeted=grp["budgeted"],
+                    balance=grp["balance"],
+                )
+            )
+        return categories
+
+    def update_category_budget(self, budget_id: str, month: str, category_id: str, amount: int) -> Dict:
+        url = f"{self.BASE_URL}/budgets/{budget_id}/months/{month}/categories/{category_id}"
+        body = {"category": {"budgeted": amount}}
+        resp = self.session.put(url, json=body)
+        resp.raise_for_status()
+        return resp.json()
+
+
+def recommend_changes(categories: List[Category]) -> List[Dict]:
+    """Suggest budget moves from positive categories to cover negatives."""
+    overspent = [c for c in categories if c.balance < 0]
+    surplus = [c for c in categories if c.balance > 0]
+    overspent.sort(key=lambda c: c.balance)
+    surplus.sort(key=lambda c: c.balance, reverse=True)
+    moves = []
+    for o in overspent:
+        needed = -o.balance
+        for s in surplus:
+            if s.balance <= 0:
+                continue
+            amount = min(needed, s.balance)
+            if amount <= 0:
+                continue
+            moves.append({"from": s.id, "to": o.id, "amount": amount})
+            s.balance -= amount
+            needed -= amount
+            if needed == 0:
+                break
+    return moves


### PR DESCRIPTION
## Summary
- add Python package structure and YNAB helper utilities
- implement `budget_cli.py` command line helper
- document usage in README
- add unit test for recommendation logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68642aac55c48324a9553a8361d592a3